### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
     <head>
     <title>DevOps Topologies</title>
@@ -324,7 +324,7 @@ we might call ‘anti-types’ (after the ubiquitous ‘anti-pattern‘).</p>
         <li><a href="#type-three">3: Ops as IaaS</a></li>  
         <li><a href="#type-four">4: DevOps-as-a-Service</a></li>
         <li><a href="#type-five">5: Temp DevOps Team</a></li>
-        <li><a href="#type-six">6: DevOps Evangelists</a></li>
+        <li><a href="#type-six">6: DevOps Advocates</a></li>
         <li><a href="#type-seven">7: SRE Team</a></li>
         <li><a href="#type-eight">8: Container-Driven</a></li>
         <li><a href="#type-nine">9: DB Capability</a></li>
@@ -486,9 +486,9 @@ we might call ‘anti-types’ (after the ubiquitous ‘anti-pattern‘).</p>
         </div>
             
         <div class="col-1-2">
-            <h5><strong>Type 6:</strong> DevOps Evangelists Team</h5>
+            <h5><strong>Type 6:</strong> DevOps Advocacy Team</h5>
 
-            <p>Within organisations that have a large gap between Dev and Ops (or the tendency towards a large gap), it can be effective to have a 'facilitating' DevOps team that keeps the Dev and Ops sides talking. This is a version of <a href="#type-five">Type 5 (DevOps Team with an Expiry Date)</a> but where the DevOps team exists on an ongoing basis with the specific remit of facilitating collaboration and cooperation between Dev and Ops teams. Members of this team are sometimes called 'DevOps Evangelists', because they help to spread awareness of DevOps practices.</p>
+            <p>Within organisations that have a large gap between Dev and Ops (or the tendency towards a large gap), it can be effective to have a 'facilitating' DevOps team that keeps the Dev and Ops sides talking. This is a version of <a href="#type-five">Type 5 (DevOps Team with an Expiry Date)</a> but where the DevOps team exists on an ongoing basis with the specific remit of facilitating collaboration and cooperation between Dev and Ops teams. Members of this team are sometimes called 'DevOps Advocates', because they help to spread awareness of DevOps practices.</p>
             
             <div class="tweet"><p><a href="https://twitter.com/ericminick/status/517335119330172930">The goal for a "DevOps Team" should be to put itself out of business by enabling the rest of the org.</a></p>
             <div class="tweet-author"><i class="fa fa-twitter"></i><a href="https://twitter.com/ericminick">EricMinick</a></div>


### PR DESCRIPTION
Rename Evangelists to Advocates

Hi Matt,
 
I've just been looking at your great work on team topologies again.
 
I've got a suggested rename for "Type 6: DevOps Evangelists Team" to "Type 6: DevOps Advocacy Team".
 
Quite a few people have switched to this term as it is a more accurate reflection of what they do and has no religious connotations. 
 
Just a thought.
 
Barry