### PR TITLE
Fix scroll position

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,13 @@
+html {
+    scroll-padding-top: 80px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    body, html {
+        scroll-behavior: smooth;
+    }
+}
+
 body {
     margin:0;
     font-family:'Lato', sans-serif;


### PR DESCRIPTION
When you share a link to a pattern or anti-pattern, the scroll position places some of the content beneath the sticky-header. For example: https://web.devopstopologies.com/#anti-type-f

This also removes the need to introduce smooth scrolling via JavaScript as the `#` links will smooth scroll where the user has no preference for reduced motion, though I haven't submitted any changes to JavaScript. I can take a look if that's wanted.

**Before**

![The title is obscured by the sticky header](https://user-images.githubusercontent.com/99181436/226297830-7e59c64a-7ed9-4bee-9d7b-6db65c39a150.png)

**After**

![The title is visible](https://user-images.githubusercontent.com/99181436/226297982-3dbe8b9c-9187-442a-8c0b-00870855ac67.png)
